### PR TITLE
Add GitHub MCP Server package

### DIFF
--- a/github-mcp-server/Dockerfile
+++ b/github-mcp-server/Dockerfile
@@ -1,0 +1,32 @@
+FROM golang:1.21-alpine AS builder
+
+WORKDIR /app
+
+# Clone the repository
+RUN apk add --no-cache git && \
+    git clone https://github.com/github/github-mcp-server.git .
+
+# Build the application
+WORKDIR /app/cmd/github-mcp-server
+RUN go build -o github-mcp-server
+
+# Create a minimal runtime image
+FROM alpine:3.19
+
+# Install ca-certificates for HTTPS connections
+RUN apk add --no-cache ca-certificates
+
+# Copy the binary from the builder stage
+COPY --from=builder /app/cmd/github-mcp-server/github-mcp-server /usr/local/bin/github-mcp-server
+
+# Create a directory for the config file
+RUN mkdir -p /etc/github-mcp-server
+
+# Create an example config file
+RUN echo '{\n  "TOOL_ADD_ISSUE_COMMENT_DESCRIPTION": "Add a comment to an existing issue",\n  "TOOL_CREATE_BRANCH_DESCRIPTION": "Create a new branch in a GitHub repository"\n}' > /etc/github-mcp-server/config.json.example
+
+# Set the entrypoint
+ENTRYPOINT ["/usr/local/bin/github-mcp-server"]
+
+# Default command
+CMD ["stdio"]

--- a/github-mcp-server/PKGBUILD
+++ b/github-mcp-server/PKGBUILD
@@ -1,0 +1,70 @@
+# Maintainer: AjayK <maintainer@example.com>
+
+pkgname=github-mcp-server
+pkgver=0.1.0
+pkgrel=1
+pkgdesc="GitHub MCP (Model Context Protocol) Server for seamless integration with GitHub APIs"
+arch=('x86_64' 'aarch64')
+url="https://github.com/github/github-mcp-server"
+license=('MIT')
+depends=('docker')
+makedepends=('go' 'git')
+optdepends=('vscode: For VS Code integration')
+provides=("${pkgname}")
+conflicts=("${pkgname}")
+options=('!strip' '!emptydirs')
+source=("${pkgname}::git+https://github.com/github/github-mcp-server.git")
+sha256sums=('SKIP')
+
+build() {
+  cd "${pkgname}"
+  export CGO_CPPFLAGS="${CPPFLAGS}"
+  export CGO_CFLAGS="${CFLAGS}"
+  export CGO_CXXFLAGS="${CXXFLAGS}"
+  export CGO_LDFLAGS="${LDFLAGS}"
+  export GOFLAGS="-buildmode=pie -trimpath -ldflags=-linkmode=external -mod=readonly -modcacherw"
+  
+  # Build from source
+  cd cmd/github-mcp-server
+  go build -o github-mcp-server
+}
+
+package() {
+  cd "${pkgname}/cmd/github-mcp-server"
+  
+  # Install binary
+  install -Dm755 github-mcp-server "${pkgdir}/usr/bin/github-mcp-server"
+  
+  # Documentation
+  cd "${srcdir}/${pkgname}"
+  install -Dm644 LICENSE "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
+  install -Dm644 README.md "${pkgdir}/usr/share/doc/${pkgname}/README.md"
+  
+  # Create systemd service file
+  mkdir -p "${pkgdir}/usr/lib/systemd/system"
+  cat > "${pkgdir}/usr/lib/systemd/system/github-mcp-server.service" << "EOF"
+[Unit]
+Description=GitHub MCP Server
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/github-mcp-server stdio
+Restart=on-failure
+Environment=GITHUB_PERSONAL_ACCESS_TOKEN=%i
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+  # Create config directory
+  mkdir -p "${pkgdir}/etc/github-mcp-server"
+  
+  # Create sample config file
+  cat > "${pkgdir}/etc/github-mcp-server/config.json.example" << "EOF"
+{
+  "TOOL_ADD_ISSUE_COMMENT_DESCRIPTION": "Add a comment to an existing issue",
+  "TOOL_CREATE_BRANCH_DESCRIPTION": "Create a new branch in a GitHub repository"
+}
+EOF
+}

--- a/github-mcp-server/README.md
+++ b/github-mcp-server/README.md
@@ -1,0 +1,108 @@
+# GitHub MCP Server Package
+
+This package contains the necessary files to build and install the [GitHub MCP Server](https://github.com/github/github-mcp-server), which is a Model Context Protocol (MCP) server that provides seamless integration with GitHub APIs.
+
+## Features
+
+- Integrate with GitHub APIs through the Model Context Protocol
+- Automate GitHub workflows and processes
+- Extract and analyze data from GitHub repositories
+- Build AI-powered tools that interact with GitHub's ecosystem
+
+## Installation Methods
+
+### Arch Linux (PKGBUILD)
+
+```bash
+# Clone this repository
+git clone https://github.com/ajayk/os.git
+cd os/github-mcp-server
+
+# Build and install the package
+makepkg -si
+```
+
+### Fedora/RHEL/CentOS (RPM)
+
+```bash
+# Clone this repository
+git clone https://github.com/ajayk/os.git
+cd os/github-mcp-server
+
+# Build the RPM package
+rpmbuild -bb github-mcp-server.spec
+
+# Install the RPM
+sudo dnf install ~/rpmbuild/RPMS/x86_64/github-mcp-server-0.1.0-1*.rpm
+```
+
+### Debian/Ubuntu (DEB)
+
+```bash
+# Clone this repository
+git clone https://github.com/ajayk/os.git
+cd os/github-mcp-server
+
+# Build the Debian package
+dpkg-buildpackage -us -uc -b
+
+# Install the package
+sudo dpkg -i ../github-mcp-server_0.1.0-1_amd64.deb
+sudo apt-get install -f  # Install any missing dependencies
+```
+
+### Docker
+
+```bash
+# Clone this repository
+git clone https://github.com/ajayk/os.git
+cd os/github-mcp-server
+
+# Build the Docker image
+docker build -t github-mcp-server .
+
+# Run the container
+docker run -i --rm -e GITHUB_PERSONAL_ACCESS_TOKEN="your_token_here" github-mcp-server
+```
+
+## Configuration
+
+After installation, you'll need to configure your GitHub Personal Access Token:
+
+1. [Create a GitHub Personal Access Token](https://github.com/settings/personal-access-tokens/new)
+2. Set the token as an environment variable:
+   ```bash
+   export GITHUB_PERSONAL_ACCESS_TOKEN="your_token_here"
+   ```
+
+### Using with VS Code
+
+Add the following to your VS Code settings.json file:
+
+```json
+{
+  "mcp": {
+    "inputs": [
+      {
+        "type": "promptString",
+        "id": "github_token",
+        "description": "GitHub Personal Access Token",
+        "password": true
+      }
+    ],
+    "servers": {
+      "github": {
+        "command": "github-mcp-server",
+        "args": ["stdio"],
+        "env": {
+          "GITHUB_PERSONAL_ACCESS_TOKEN": "${input:github_token}"
+        }
+      }
+    }
+  }
+}
+```
+
+## License
+
+This package is under the same license as the original GitHub MCP Server (MIT).

--- a/github-mcp-server/debian/changelog
+++ b/github-mcp-server/debian/changelog
@@ -1,0 +1,5 @@
+github-mcp-server (0.1.0-1) unstable; urgency=medium
+
+  * Initial release.
+
+ -- AjayK <maintainer@example.com>  Mon, 07 Apr 2025 12:00:00 +0000

--- a/github-mcp-server/debian/config.json.example
+++ b/github-mcp-server/debian/config.json.example
@@ -1,0 +1,16 @@
+{
+  "TOOL_ADD_ISSUE_COMMENT_DESCRIPTION": "Add a comment to an existing issue",
+  "TOOL_CREATE_BRANCH_DESCRIPTION": "Create a new branch in a GitHub repository",
+  "TOOL_CREATE_ISSUE_DESCRIPTION": "Create a new issue in a GitHub repository",
+  "TOOL_CREATE_OR_UPDATE_FILE_DESCRIPTION": "Create or update a single file in a GitHub repository",
+  "TOOL_CREATE_PULL_REQUEST_DESCRIPTION": "Create a new pull request in a GitHub repository",
+  "TOOL_GET_FILE_CONTENTS_DESCRIPTION": "Get the contents of a file or directory from a GitHub repository",
+  "TOOL_GET_ISSUE_DESCRIPTION": "Gets the contents of an issue within a repository",
+  "TOOL_GET_PULL_REQUEST_DESCRIPTION": "Get details of a specific pull request",
+  "TOOL_LIST_COMMITS_DESCRIPTION": "Get list of commits of a branch in a GitHub repository",
+  "TOOL_LIST_ISSUES_DESCRIPTION": "List issues in a GitHub repository with filtering options",
+  "TOOL_LIST_PULL_REQUESTS_DESCRIPTION": "List and filter repository pull requests",
+  "TOOL_SEARCH_CODE_DESCRIPTION": "Search for code across GitHub repositories",
+  "TOOL_SEARCH_ISSUES_DESCRIPTION": "Search for issues and pull requests across GitHub repositories",
+  "TOOL_SEARCH_REPOSITORIES_DESCRIPTION": "Search for GitHub repositories"
+}

--- a/github-mcp-server/debian/control
+++ b/github-mcp-server/debian/control
@@ -1,0 +1,24 @@
+Source: github-mcp-server
+Section: devel
+Priority: optional
+Maintainer: AjayK <maintainer@example.com>
+Build-Depends: debhelper-compat (= 13), golang-go (>= 1.21), git
+Standards-Version: 4.6.0
+Homepage: https://github.com/github/github-mcp-server
+Rules-Requires-Root: no
+
+Package: github-mcp-server
+Architecture: any
+Depends: ${shlibs:Depends}, ${misc:Depends}, docker.io (>= 20.10.0)
+Recommends: vscode
+Description: GitHub MCP (Model Context Protocol) Server
+ The GitHub MCP Server is a Model Context Protocol (MCP) server
+ that provides seamless integration with GitHub APIs, enabling
+ advanced automation and interaction capabilities for developers
+ and tools.
+ .
+ It can be used for:
+  * Automating GitHub workflows and processes
+  * Extracting and analyzing data from GitHub repositories
+  * Building AI powered tools and applications that interact with
+    GitHub's ecosystem

--- a/github-mcp-server/debian/github-mcp-server.service
+++ b/github-mcp-server/debian/github-mcp-server.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=GitHub MCP Server
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/github-mcp-server stdio
+Restart=on-failure
+Environment=GITHUB_PERSONAL_ACCESS_TOKEN=
+
+[Install]
+WantedBy=multi-user.target

--- a/github-mcp-server/debian/install
+++ b/github-mcp-server/debian/install
@@ -1,0 +1,3 @@
+cmd/github-mcp-server/github-mcp-server usr/bin/
+debian/github-mcp-server.service lib/systemd/system/
+debian/config.json.example etc/github-mcp-server/

--- a/github-mcp-server/debian/rules
+++ b/github-mcp-server/debian/rules
@@ -1,0 +1,25 @@
+#!/usr/bin/make -f
+export DH_VERBOSE = 1
+export DH_GOPKG = github.com/github/github-mcp-server
+export GOPROXY=https://proxy.golang.org,direct
+
+%:
+	dh $@
+
+override_dh_auto_build:
+	# Build the binary
+	cd cmd/github-mcp-server && go build -v -o github-mcp-server
+
+override_dh_auto_test:
+	# Skip tests during package build
+
+override_dh_auto_install:
+	# Install binary
+	install -D -m 0755 cmd/github-mcp-server/github-mcp-server $(CURDIR)/debian/github-mcp-server/usr/bin/github-mcp-server
+	
+	# Install systemd service
+	install -D -m 0644 debian/github-mcp-server.service $(CURDIR)/debian/github-mcp-server/lib/systemd/system/github-mcp-server.service
+	
+	# Create config directory and example file
+	install -d -m 0755 $(CURDIR)/debian/github-mcp-server/etc/github-mcp-server
+	install -m 0644 debian/config.json.example $(CURDIR)/debian/github-mcp-server/etc/github-mcp-server/

--- a/github-mcp-server/github-mcp-server.spec
+++ b/github-mcp-server/github-mcp-server.spec
@@ -1,0 +1,81 @@
+%global debug_package %{nil}
+
+Name:           github-mcp-server
+Version:        0.1.0
+Release:        1%{?dist}
+Summary:        GitHub MCP (Model Context Protocol) Server
+License:        MIT
+URL:            https://github.com/github/github-mcp-server
+Source0:        https://github.com/github/github-mcp-server/archive/refs/heads/main.tar.gz
+
+BuildRequires:  golang >= 1.21
+BuildRequires:  git
+Requires:       docker-ce >= 20.10.0
+
+%description
+The GitHub MCP Server is a Model Context Protocol (MCP) server that provides
+seamless integration with GitHub APIs, enabling advanced automation and
+interaction capabilities for developers and tools.
+
+%prep
+%autosetup -n %{name}-main
+
+%build
+cd cmd/github-mcp-server
+go build -o github-mcp-server
+
+%install
+mkdir -p %{buildroot}%{_bindir}
+install -p -m 755 cmd/github-mcp-server/github-mcp-server %{buildroot}%{_bindir}/github-mcp-server
+
+# Install documentation
+mkdir -p %{buildroot}%{_docdir}/%{name}
+install -p -m 644 README.md %{buildroot}%{_docdir}/%{name}/
+install -p -m 644 LICENSE %{buildroot}%{_docdir}/%{name}/
+
+# Install systemd service file
+mkdir -p %{buildroot}%{_unitdir}
+cat > %{buildroot}%{_unitdir}/github-mcp-server.service << EOF
+[Unit]
+Description=GitHub MCP Server
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=%{_bindir}/github-mcp-server stdio
+Restart=on-failure
+Environment=GITHUB_PERSONAL_ACCESS_TOKEN=
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+# Create configuration directory
+mkdir -p %{buildroot}%{_sysconfdir}/github-mcp-server
+cat > %{buildroot}%{_sysconfdir}/github-mcp-server/config.json.example << EOF
+{
+  "TOOL_ADD_ISSUE_COMMENT_DESCRIPTION": "Add a comment to an existing issue",
+  "TOOL_CREATE_BRANCH_DESCRIPTION": "Create a new branch in a GitHub repository"
+}
+EOF
+
+%files
+%license LICENSE
+%doc README.md
+%{_bindir}/github-mcp-server
+%{_unitdir}/github-mcp-server.service
+%dir %{_sysconfdir}/github-mcp-server
+%config(noreplace) %{_sysconfdir}/github-mcp-server/config.json.example
+
+%post
+%systemd_post github-mcp-server.service
+
+%preun
+%systemd_preun github-mcp-server.service
+
+%postun
+%systemd_postun_with_restart github-mcp-server.service
+
+%changelog
+* Mon Apr 07 2025 AjayK <maintainer@example.com> - 0.1.0-1
+- Initial package


### PR DESCRIPTION
This PR adds packaging for the GitHub MCP Server (https://github.com/github/github-mcp-server).

The GitHub MCP Server is a Model Context Protocol (MCP) server that provides seamless integration with GitHub APIs, enabling advanced automation and interaction capabilities for developers and tools.

## Package details
- Added PKGBUILD for Arch Linux
- Added RPM spec file for Fedora/RHEL
- Added Debian packaging files
- Added Dockerfile for container-based deployment
- Added comprehensive README with installation instructions

## Usage
This package allows users to easily install and run the GitHub MCP Server, which can be used with VS Code and other tools that support the Model Context Protocol for GitHub API integration.

## Testing
The package has been tested on:
- Building from source
- Docker deployment
- Integration with VS Code

Please let me know if any changes are needed!